### PR TITLE
feat: added omni xchain ui changes

### DIFF
--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -36,6 +36,7 @@ import './lib/modals'
 import './lib/card_tabs'
 import './lib/ad'
 import './lib/dark_mode'
+import './omni'
 
 import swal from 'sweetalert2'
 // @ts-ignore

--- a/apps/block_scout_web/assets/js/omni.js
+++ b/apps/block_scout_web/assets/js/omni.js
@@ -1,0 +1,163 @@
+// local cache to re-use data
+let txMap = {};
+
+// default api url point to local server
+let url = "http://localhost:8888";
+
+const customMarker = () => {
+  const div = document.createElement("div");
+  div.style =
+    "height: inherit;margin-left: 1vw;background-color: #8258cd;padding: 0 0.5vw;border-radius: 1vw;";
+  div.innerHTML =
+    '<img style="height: 1.5vw;display: inline-block;margin-top: -0.1vw" src="/images/favicon-32x32.png"> <div style="margin-top: 0.2vw;display: inline-block;font-weight: bolder;color: white;">X-Chain</div>';
+  return div;
+};
+
+const customXChainDataView = (details) => {
+  const div = document.createElement("div");
+  div.style =
+    "height: inherit;background-color: rgb(130, 88, 205);padding: 2.5vw 1.5vw 0vw 1.5vw;";
+  div.innerHTML = `
+  <div>
+  <img style="height: 2vw; display: inline-block;margin-top: -0.3vw" src="/images/favicon-32x32.png"> 
+  <div style="margin-top: 0.1vw;display: inline-block;font-weight: bolder;color: white;font-size: 1.2vw;padding-left: 0.5vw;">X-Chain Transaction Details</div></div>
+  <pre style="font-size: 1vw;display: block;margin-top: 0.5vw;font-weight: bolder;color: white;padding-left: 1vw;">
+  ${JSON.stringify(details, null, 4)}
+  </pre>`;
+  return div;
+};
+
+// expected return {txHash1:true, txHas2:true...}
+const checkTx = async (elements) => {
+  const response = await fetch(url + "/checkOmniTxHashes", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      txHashes: elements,
+    }),
+  });
+  if (response.status == 400) {
+    await response.json().then(console.error);
+    return undefined;
+  }
+  return response.json();
+};
+
+const getTxDetails = async (omniTxHash) => {
+  // dummy response
+  const response = await fetch(url + `/omniTx/${omniTxHash}`);
+  const data = await response.json();
+  if (data.length === 0) {
+    return undefined;
+  }
+  return data;
+};
+
+const getAllTxHashElements = () => {
+  return document.querySelectorAll('[data-test="transaction_hash_link"]');
+};
+
+const handletxHashLinks = async () => {
+  const elements = getAllTxHashElements();
+  if (elements.length == 0) {
+    return;
+  }
+  // check local cache
+  const unknownTxList = [];
+  for (let i of elements) {
+    if (i.parentNode.childElementCount <= 2 && txMap[i.innerHTML] === true) {
+      console.log("from cache " + i.innerHTML);
+      i.parentNode.appendChild(customMarker());
+    } else if (txMap[i.innerHTML] === undefined) {
+      unknownTxList.push(i.innerHTML);
+    }
+  }
+  if (unknownTxList.length == 0) {
+    return;
+  }
+  const xChainTxs = await checkTx(unknownTxList);
+  if (xChainTxs === undefined) {
+    return;
+  }
+  for (let i of elements) {
+    if (xChainTxs[i.innerHTML] === true) {
+      txMap[i.innerHTML] = true;
+      console.log("from api " + i.innerHTML);
+      i.parentNode.appendChild(customMarker());
+    } else if (txMap[i.innerHTML] == undefined) {
+      txMap[i.innerHTML] = false;
+    }
+  }
+};
+
+const displayTxDetails = async (txHash) => {
+  const elements = document.querySelectorAll(
+    '[class="card js-ad-dependant-mb-3"]'
+  );
+  if (elements.length != 1) {
+    console.log("could not find unique tx view element");
+    return;
+  }
+
+  const details = await getTxDetails(txHash);
+  if (details === undefined) return;
+
+  // if tx has cross chain data display
+  elements[0].appendChild(customXChainDataView(details));
+};
+
+// sets next repeat only after the function call completes
+const repeatLoop = async (timeMS) => {
+  try {
+    await handletxHashLinks();
+  } catch (err) {
+    console.log(err);
+  } finally {
+    setTimeout(repeatLoop, timeMS);
+  }
+};
+
+const watch = async () => {
+
+  // update api url depending on blockscouts deployed environment
+  if (window.location.hostname.startsWith("testnet")) {
+    url = "testnet-1-xchain.explorer.omni.network";
+  } else if (window.location.hostname.startsWith("staging")) {
+    url = "staging-xchain.explorer.omni.network";
+  }
+
+  // handle for homepage
+  if (window.location.pathname === "/") {
+    repeatLoop(1500);
+  } else if (window.location.pathname.startsWith("/address/")) {
+    // every 5 second because there can be too many updates
+    repeatLoop(2000);
+  } else if (
+    window.location.pathname.match(/\/token(.*)\/token-transfers/g) != null &&
+    window.location.pathname.match(/\/token(.*)\/token-transfers/g).length != 0
+  ) {
+    // every 5 second because there can be too many updates
+    repeatLoop(2000);
+  } else if (window.location.pathname === "/txs") {
+    // every 5 second because there can be too many updates
+    repeatLoop(2000);
+  } else if (
+    window.location.pathname.match(/\/block(.*)\/transactions/g) != null &&
+    window.location.pathname.match(/\/block(.*)\/transactions/g).length != 0
+  ) {
+    repeatLoop(1000);
+  } else if (window.location.pathname.startsWith("/tx/")) {
+    // get txHash
+    const omniTxHash = window.location.pathname.split("/")[2];
+    if (omniTxHash === undefined || !omniTxHash.startsWith("0x")) {
+      console.log("cannot parse txHash on tx details page");
+      return;
+    }
+
+    displayTxDetails(omniTxHash);
+  }
+};
+
+watch();

--- a/apps/block_scout_web/assets/js/omni.js
+++ b/apps/block_scout_web/assets/js/omni.js
@@ -1,8 +1,8 @@
 // local cache to re-use data
-let txMap = {};
+let txMapCache = {};
 
-// default api url point to local server
-let url = "http://localhost:8888";
+// default api indexerUrl point to local server
+let indexerUrl = "http://localhost:8888";
 
 const xchainMarker = () => {
   const div = document.createElement("div");
@@ -30,7 +30,7 @@ const customXChainDataView = (details) => {
 // expected return {txHash1:true, txHas2:true...}
 const getXChainTxs = async (elements) => {
   try {
-    const response = await fetch(url + "/checkOmniTxHashes", {
+    const response = await fetch(indexerUrl + "/checkOmniTxHashes", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -52,7 +52,7 @@ const getXChainTxs = async (elements) => {
 
 const getTxDetails = async (omniTxHash) => {
   try {
-    const response = await fetch(url + `/omniTx/${omniTxHash}`);
+    const response = await fetch(indexerUrl + `/omniTx/${omniTxHash}`);
     const data = await response.json();
     if (data.length === 0) {
       return undefined;
@@ -76,10 +76,13 @@ const handletxHashLinks = async () => {
   // check local cache
   const unknownTxList = [];
   for (let i of elements) {
-    if (i.parentNode.childElementCount <= 2 && txMap[i.innerHTML] === true) {
+    if (
+      i.parentNode.childElementCount <= 2 &&
+      txMapCache[i.innerHTML] === true
+    ) {
       console.log("from cache " + i.innerHTML);
       i.parentNode.appendChild(xchainMarker());
-    } else if (txMap[i.innerHTML] === undefined) {
+    } else if (txMapCache[i.innerHTML] === undefined) {
       unknownTxList.push(i.innerHTML);
     }
   }
@@ -92,11 +95,11 @@ const handletxHashLinks = async () => {
   }
   for (let i of elements) {
     if (xChainTxs[i.innerHTML] === true) {
-      txMap[i.innerHTML] = true;
+      txMapCache[i.innerHTML] = true;
       console.log("from api " + i.innerHTML);
       i.parentNode.appendChild(xchainMarker());
-    } else if (txMap[i.innerHTML] == undefined) {
-      txMap[i.innerHTML] = false;
+    } else if (txMapCache[i.innerHTML] == undefined) {
+      txMapCache[i.innerHTML] = false;
     }
   }
 };
@@ -129,11 +132,11 @@ const repeatLoop = async (timeMS) => {
 };
 
 const watch = async () => {
-  // update api url depending on blockscouts deployed environment
+  // update api indexerUrl depending on blockscouts deployed environment
   if (window.location.hostname.startsWith("testnet")) {
-    url = "https://testnet-1-xapi.explorer.omni.network";
+    indexerUrl = "https://testnet-1-xapi.explorer.omni.network";
   } else if (window.location.hostname.startsWith("staging")) {
-    url = "https://staging-xapi.explorer.omni.network";
+    indexerUrl = "https://staging-xapi.explorer.omni.network";
   }
 
   // handle for homepage

--- a/apps/block_scout_web/assets/js/omni.js
+++ b/apps/block_scout_web/assets/js/omni.js
@@ -122,9 +122,9 @@ const repeatLoop = async (timeMS) => {
 const watch = async () => {
   // update api url depending on blockscouts deployed environment
   if (window.location.hostname.startsWith("testnet")) {
-    url = "testnet-1-xchain.explorer.omni.network";
+    url = "https://testnet-1-xchain.explorer.omni.network";
   } else if (window.location.hostname.startsWith("staging")) {
-    url = "staging-xchain.explorer.omni.network";
+    url = "https://staging-xchain.explorer.omni.network";
   }
 
   // handle for homepage

--- a/apps/block_scout_web/assets/js/omni.js
+++ b/apps/block_scout_web/assets/js/omni.js
@@ -29,30 +29,39 @@ const customXChainDataView = (details) => {
 
 // expected return {txHash1:true, txHas2:true...}
 const getXChainTxs = async (elements) => {
-  const response = await fetch(url + "/checkOmniTxHashes", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      txHashes: elements,
-    }),
-  });
-  if (response.status == 400) {
-    await response.json().then(console.error);
+  try {
+    const response = await fetch(url + "/checkOmniTxHashes", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        txHashes: elements,
+      }),
+    });
+    if (response.status == 400) {
+      await response.json().then(console.error);
+      return undefined;
+    }
+    return response.json();
+  } catch (err) {
+    console.error("error getting xchain txs: ", err);
     return undefined;
   }
-  return response.json();
 };
 
 const getTxDetails = async (omniTxHash) => {
-  // dummy response
-  const response = await fetch(url + `/omniTx/${omniTxHash}`);
-  const data = await response.json();
-  if (data.length === 0) {
+  try {
+    const response = await fetch(url + `/omniTx/${omniTxHash}`);
+    const data = await response.json();
+    if (data.length === 0) {
+      return undefined;
+    }
+    return data;
+  } catch (err) {
+    console.error("error getting xchain tx details: ", omniTxHash, " ", err);
     return undefined;
   }
-  return data;
 };
 
 const getAllTxHashElements = () => {

--- a/apps/block_scout_web/assets/js/omni.js
+++ b/apps/block_scout_web/assets/js/omni.js
@@ -122,9 +122,9 @@ const repeatLoop = async (timeMS) => {
 const watch = async () => {
   // update api url depending on blockscouts deployed environment
   if (window.location.hostname.startsWith("testnet")) {
-    url = "https://testnet-1-xchain.explorer.omni.network";
+    url = "https://testnet-1-xapi.explorer.omni.network";
   } else if (window.location.hostname.startsWith("staging")) {
-    url = "https://staging-xchain.explorer.omni.network";
+    url = "https://staging-xapi.explorer.omni.network";
   }
 
   // handle for homepage

--- a/apps/block_scout_web/assets/js/omni.js
+++ b/apps/block_scout_web/assets/js/omni.js
@@ -4,7 +4,7 @@ let txMap = {};
 // default api url point to local server
 let url = "http://localhost:8888";
 
-const customMarker = () => {
+const xchainMarker = () => {
   const div = document.createElement("div");
   div.style =
     "height: inherit;margin-left: 1vw;background-color: #8258cd;padding: 0 0.5vw;border-radius: 1vw;";
@@ -28,7 +28,7 @@ const customXChainDataView = (details) => {
 };
 
 // expected return {txHash1:true, txHas2:true...}
-const checkTx = async (elements) => {
+const getXChainTxs = async (elements) => {
   const response = await fetch(url + "/checkOmniTxHashes", {
     method: "POST",
     headers: {
@@ -69,7 +69,7 @@ const handletxHashLinks = async () => {
   for (let i of elements) {
     if (i.parentNode.childElementCount <= 2 && txMap[i.innerHTML] === true) {
       console.log("from cache " + i.innerHTML);
-      i.parentNode.appendChild(customMarker());
+      i.parentNode.appendChild(xchainMarker());
     } else if (txMap[i.innerHTML] === undefined) {
       unknownTxList.push(i.innerHTML);
     }
@@ -77,7 +77,7 @@ const handletxHashLinks = async () => {
   if (unknownTxList.length == 0) {
     return;
   }
-  const xChainTxs = await checkTx(unknownTxList);
+  const xChainTxs = await getXChainTxs(unknownTxList);
   if (xChainTxs === undefined) {
     return;
   }
@@ -85,7 +85,7 @@ const handletxHashLinks = async () => {
     if (xChainTxs[i.innerHTML] === true) {
       txMap[i.innerHTML] = true;
       console.log("from api " + i.innerHTML);
-      i.parentNode.appendChild(customMarker());
+      i.parentNode.appendChild(xchainMarker());
     } else if (txMap[i.innerHTML] == undefined) {
       txMap[i.innerHTML] = false;
     }
@@ -120,7 +120,6 @@ const repeatLoop = async (timeMS) => {
 };
 
 const watch = async () => {
-
   // update api url depending on blockscouts deployed environment
   if (window.location.hostname.startsWith("testnet")) {
     url = "testnet-1-xchain.explorer.omni.network";
@@ -132,16 +131,16 @@ const watch = async () => {
   if (window.location.pathname === "/") {
     repeatLoop(1500);
   } else if (window.location.pathname.startsWith("/address/")) {
-    // every 5 second because there can be too many updates
+    // every 2 second because there can be too many updates
     repeatLoop(2000);
   } else if (
     window.location.pathname.match(/\/token(.*)\/token-transfers/g) != null &&
     window.location.pathname.match(/\/token(.*)\/token-transfers/g).length != 0
   ) {
-    // every 5 second because there can be too many updates
+    // every 2 second because there can be too many updates
     repeatLoop(2000);
   } else if (window.location.pathname === "/txs") {
-    // every 5 second because there can be too many updates
+    // every 2 second because there can be too many updates
     repeatLoop(2000);
   } else if (
     window.location.pathname.match(/\/block(.*)\/transactions/g) != null &&

--- a/apps/block_scout_web/lib/block_scout_web/csp_header.ex
+++ b/apps/block_scout_web/lib/block_scout_web/csp_header.ex
@@ -19,7 +19,7 @@ defmodule BlockScoutWeb.CSPHeader do
 
     Controller.put_secure_browser_headers(conn, %{
       "content-security-policy" => "\
-        connect-src 'self' http://localhost:8888 https://testnet-1-xchain.explorer.omni.network https://staging-xchain.explorer.omni.network #{json_rpc_url} #{config[:mixpanel_url]} #{config[:amplitude_url]} #{websocket_endpoints(conn)} #{czilladx_url} #{trustwallet_url} #{walletconnect_urls};\
+        connect-src 'self' http://localhost:8888 https://testnet-1-xapi.explorer.omni.network https://staging-xapi.explorer.omni.network #{json_rpc_url} #{config[:mixpanel_url]} #{config[:amplitude_url]} #{websocket_endpoints(conn)} #{czilladx_url} #{trustwallet_url} #{walletconnect_urls};\
         default-src 'self';\
         script-src 'self' 'unsafe-inline' 'unsafe-eval' #{coinzillatag_url} #{google_url} https://www.gstatic.com;\
         style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;\

--- a/apps/block_scout_web/lib/block_scout_web/csp_header.ex
+++ b/apps/block_scout_web/lib/block_scout_web/csp_header.ex
@@ -19,7 +19,7 @@ defmodule BlockScoutWeb.CSPHeader do
 
     Controller.put_secure_browser_headers(conn, %{
       "content-security-policy" => "\
-        connect-src 'self' #{json_rpc_url} #{config[:mixpanel_url]} #{config[:amplitude_url]} #{websocket_endpoints(conn)} #{czilladx_url} #{trustwallet_url} #{walletconnect_urls};\
+        connect-src 'self' http://localhost:8888 https://testnet-1-xchain.explorer.omni.network https://staging-xchain.explorer.omni.network #{json_rpc_url} #{config[:mixpanel_url]} #{config[:amplitude_url]} #{websocket_endpoints(conn)} #{czilladx_url} #{trustwallet_url} #{walletconnect_urls};\
         default-src 'self';\
         script-src 'self' 'unsafe-inline' 'unsafe-eval' #{coinzillatag_url} #{google_url} https://www.gstatic.com;\
         style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;\


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

This PR adds ability to display omni xchain txs in the explorer

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
