### PR TITLE
Use BLOCKSCOUT_VERSION as RELEASE_VERSION build arg.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -751,6 +751,7 @@ ifdef INDEXER_TOKEN_INSTANCE_SANITIZE_BATCH_SIZE
 	BLOCKSCOUT_CONTAINER_PARAMS += -e 'INDEXER_TOKEN_INSTANCE_SANITIZE_BATCH_SIZE=$(INDEXER_TOKEN_INSTANCE_SANITIZE_BATCH_SIZE)'
 endif
 
+# use BLOCKSCOUT_VERSION as release version (app file structure relies on it)
 HAS_BLOCKSCOUT_IMAGE := $(shell docker images | grep -sw "${BS_CONTAINER_IMAGE} ")
 build:
 	@echo "==> Checking for blockscout image $(BS_CONTAINER_IMAGE)"
@@ -758,7 +759,7 @@ ifdef HAS_BLOCKSCOUT_IMAGE
 	@echo "==> Image exist. Using $(BS_CONTAINER_IMAGE)"
 else
 	@echo "==> No image found, trying to build one..."
-	@docker build -f ./Dockerfile --build-arg RELEASE_VERSION=$(RELEASE_VERSION) -t $(BS_CONTAINER_IMAGE) ../
+	@docker build -f ./Dockerfile --build-arg RELEASE_VERSION=$(BLOCKSCOUT_VERSION) -t $(BS_CONTAINER_IMAGE) ../
 endif
 
 migrate_only:


### PR DESCRIPTION
App file structure relies on RELEASE_VERSION matching the blockscout
release version, not the omniops release version.