### PR TITLE
Add omni css to main page.

### DIFF
--- a/apps/block_scout_web/assets/css/main-page.scss
+++ b/apps/block_scout_web/assets/css/main-page.scss
@@ -48,6 +48,7 @@ a.disabled {
 @import "theme/fonts";
 
 // Custom SCSS
+@import "omni";
 @import "layout";
 @import "typography";
 @import "helpers";


### PR DESCRIPTION
Importing _omni.scss in app.scss does not include omni on the main page. Importing in main-page.scss does.
