### PR TITLE
Remove multi platform builds from GH actions.

### DIFF
--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -62,9 +62,6 @@ jobs:
           cache-from: type=registry,ref=omniops/blockscout:buildcache
           cache-to: type=registry,ref=omniops/blockscout:buildcache,mode=max
           tags: omniops/blockscout:main, omniops/blockscout:${{ env.RELEASE_VERSION }}-beta.commit.${{ env.SHORT_SHA }}
-          platforms: |
-            linux/arm64
-            linux/amd64
           build-args: |
             CACHE_EXCHANGE_RATES_PERIOD=
             API_V1_READ_METHODS_DISABLED=false

--- a/.github/workflows/publish-docker-image-release.yml
+++ b/.github/workflows/publish-docker-image-release.yml
@@ -54,9 +54,6 @@ jobs:
           cache-from: type=registry,ref=omniops/blockscout:buildcache
           cache-to: type=registry,ref=omniops/blockscout:buildcache,mode=max
           tags: omniops/blockscout:latest, omniops/blockscout:${{ env.RELEASE_VERSION }}
-          platforms: |
-            linux/arm64
-            linux/amd64
           build-args: |
             CACHE_EXCHANGE_RATES_PERIOD=
             API_V1_READ_METHODS_DISABLED=false


### PR DESCRIPTION
Specifying multiple platforms causes the GH build and push action to hang indefinitely. To run on amd architectures, we can build locally.


