### PR TITLE
significantly reduce file logs

### DIFF
--- a/apps/block_scout_web/config/prod.exs
+++ b/apps/block_scout_web/config/prod.exs
@@ -22,18 +22,18 @@ config :block_scout_web, BlockScoutWeb.Tracer, env: "production", disabled?: tru
 config :logger, :block_scout_web,
   level: :info,
   path: Path.absname("logs/prod/block_scout_web.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :api,
   level: :debug,
   path: Path.absname("logs/prod/api.log"),
   metadata_filter: [application: :api],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :api_v2,
   level: :debug,
   path: Path.absname("logs/prod/api_v2.log"),
   metadata_filter: [application: :api_v2],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :block_scout_web, :captcha_helper, BlockScoutWeb.CaptchaHelper

--- a/apps/ethereum_jsonrpc/config/prod.exs
+++ b/apps/ethereum_jsonrpc/config/prod.exs
@@ -5,4 +5,4 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Tracer, env: "production", disabled?: 
 config :logger, :ethereum_jsonrpc,
   level: :info,
   path: Path.absname("logs/prod/ethereum_jsonrpc.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -21,16 +21,16 @@ config :explorer, Explorer.Tracer, env: "production", disabled?: true
 config :logger, :explorer,
   level: :info,
   path: Path.absname("logs/prod/explorer.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :reading_token_functions,
   level: :debug,
   path: Path.absname("logs/prod/explorer/tokens/reading_functions.log"),
   metadata_filter: [fetcher: :token_functions],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :token_instances,
   level: :debug,
   path: Path.absname("logs/prod/explorer/tokens/token_instances.log"),
   metadata_filter: [fetcher: :token_instances],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -5,46 +5,46 @@ config :indexer, Indexer.Tracer, env: "production", disabled?: true
 config :logger, :indexer,
   level: :info,
   path: Path.absname("logs/prod/indexer.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :indexer_token_balances,
   level: :debug,
   path: Path.absname("logs/prod/indexer/token_balances/error.log"),
   metadata_filter: [fetcher: :token_balances],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :failed_contract_creations,
   level: :debug,
   path: Path.absname("logs/prod/indexer/failed_contract_creations.log"),
   metadata_filter: [fetcher: :failed_created_addresses],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :addresses_without_code,
   level: :debug,
   path: Path.absname("logs/prod/indexer/addresses_without_code.log"),
   metadata_filter: [fetcher: :addresses_without_code],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :pending_transactions_to_refetch,
   level: :debug,
   path: Path.absname("logs/prod/indexer/pending_transactions_to_refetch.log"),
   metadata_filter: [fetcher: :pending_transactions_to_refetch],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :empty_blocks_to_refetch,
   level: :info,
   path: Path.absname("logs/prod/indexer/empty_blocks_to_refetch.log"),
   metadata_filter: [fetcher: :empty_blocks_to_refetch],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :block_import_timings,
   level: :debug,
   path: Path.absname("logs/prod/indexer/block_import_timings.log"),
   metadata_filter: [fetcher: :block_import_timings],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :withdrawal,
   level: :info,
   path: Path.absname("logs/prod/indexer/withdrawal.log"),
   metadata_filter: [fetcher: :withdrawal],
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,14 +7,14 @@ config :logger, :console, level: :info
 config :logger, :ecto,
   level: :info,
   path: Path.absname("logs/prod/ecto.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :error,
   path: Path.absname("logs/prod/error.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 1_048_576, keep: 1}
 
 config :logger, :account,
   level: :info,
   path: Path.absname("logs/prod/account.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19},
+  rotate: %{max_bytes: 1_048_576, keep: 1},
   metadata_filter: [fetcher: :account]


### PR DESCRIPTION
Reduce the log files on disk from 20 * 50MB ~= 1GB per file, of total 18 loggers, so 18GB, to single 1MB file per logger, so max 18MB in total. We push logs to grafana, so disk logs mainly useful for dev. Some logs on disk probably isn't the end of the world.
